### PR TITLE
Изменил поле translatedText в ExampleOfDefinitionUse

### DIFF
--- a/app/src/main/kotlin/com/designdrivendevelopment/kotelok/entities/ExampleOfDefinitionUse.kt
+++ b/app/src/main/kotlin/com/designdrivendevelopment/kotelok/entities/ExampleOfDefinitionUse.kt
@@ -2,5 +2,5 @@ package com.designdrivendevelopment.kotelok.entities
 
 data class ExampleOfDefinitionUse(
     val originalText: String,
-    val translatedText: String
+    val translatedText: String?
 )

--- a/app/src/main/kotlin/com/designdrivendevelopment/kotelok/repositoryImplementations/extensions/EntitiesToRoomEntitiesExt.kt
+++ b/app/src/main/kotlin/com/designdrivendevelopment/kotelok/repositoryImplementations/extensions/EntitiesToRoomEntitiesExt.kt
@@ -57,6 +57,6 @@ fun ExampleOfDefinitionUse.toExampleEntity(wordDefId: Long): ExampleEntity {
     return ExampleEntity(
         wordDefinitionId = wordDefId,
         original = originalText,
-        translation = if (translatedText.isEmpty()) null else translatedText
+        translation = translatedText
     )
 }

--- a/app/src/main/kotlin/com/designdrivendevelopment/kotelok/repositoryImplementations/extensions/ResponseToEntitiesExt.kt
+++ b/app/src/main/kotlin/com/designdrivendevelopment/kotelok/repositoryImplementations/extensions/ResponseToEntitiesExt.kt
@@ -25,7 +25,7 @@ fun TranslationResponse.toWordDefinition(
         examples = examples?.map { exampleResponse ->
             ExampleOfDefinitionUse(
                 originalText = exampleResponse.original,
-                translatedText = exampleResponse.translations?.first()?.translation.orEmpty()
+                translatedText = exampleResponse.translations?.first()?.translation
             )
         }.orEmpty()
     )

--- a/app/src/main/kotlin/com/designdrivendevelopment/kotelok/repositoryImplementations/extensions/RoomEntitiesToEntitiesExt.kt
+++ b/app/src/main/kotlin/com/designdrivendevelopment/kotelok/repositoryImplementations/extensions/RoomEntitiesToEntitiesExt.kt
@@ -17,6 +17,6 @@ fun DictionaryEntity.toDictionary(size: Int): Dictionary {
 fun ExampleEntity.toExampleOfDefinitionUse(): ExampleOfDefinitionUse {
     return ExampleOfDefinitionUse(
         originalText = this.original,
-        translatedText = this.translation.orEmpty()
+        translatedText = this.translation
     )
 }

--- a/app/src/main/kotlin/com/designdrivendevelopment/kotelok/screens/dictionaries/dictionaryDetailsScreen/WordDefinitionsAdapter.kt
+++ b/app/src/main/kotlin/com/designdrivendevelopment/kotelok/screens/dictionaries/dictionaryDetailsScreen/WordDefinitionsAdapter.kt
@@ -44,7 +44,7 @@ class WordDefinitionsAdapter(
                 val mainExample = definition.examples.first()
                 originalExampleText.visibility = View.VISIBLE
                 originalExampleText.text = mainExample.originalText.capitalize()
-                if (mainExample.translatedText.isNotEmpty()) {
+                if (mainExample.translatedText != null) {
                     translationExampleText.visibility = View.VISIBLE
                     translationExampleText.text = mainExample.translatedText.capitalize()
                 } else {

--- a/app/src/main/kotlin/com/designdrivendevelopment/kotelok/screens/dictionaries/lookupWordDefinitionsScreen/ItemWithTypesAdapter.kt
+++ b/app/src/main/kotlin/com/designdrivendevelopment/kotelok/screens/dictionaries/lookupWordDefinitionsScreen/ItemWithTypesAdapter.kt
@@ -46,7 +46,7 @@ class ItemWithTypesAdapter(
                 val mainExample = definition.examples.first()
                 originalExampleText.visibility = View.VISIBLE
                 originalExampleText.text = mainExample.originalText.capitalize()
-                if (mainExample.translatedText.isNotEmpty()) {
+                if (mainExample.translatedText != null) {
                     translationExampleText.visibility = View.VISIBLE
                     translationExampleText.text = mainExample.translatedText.capitalize()
                 } else {


### PR DESCRIPTION
Теперь translatedText nullable и в случае его отсутствия соответствующе обрабатывается, а не как пустая строка